### PR TITLE
Add integration tests for cascade detection pipeline (#29)

### DIFF
--- a/tests/test_integration_cascade.py
+++ b/tests/test_integration_cascade.py
@@ -1,0 +1,155 @@
+"""
+Integration tests for the cascade detection pipeline (cascade.py).
+
+Unlike tests/test_cascade.py — which exercises detect_cascade() with minimal,
+single-purpose fixtures — these tests feed in news items shaped like the
+output of data_fetcher.fetch_market_headlines() (title/body/source/date/url)
+and assert on the full, realistic result: the right drivers fire, the right
+tickers are attached, and the Bullish/Bearish semantics are correct end to end.
+
+No mocking is required: detect_cascade() is a pure transformation over the
+news list plus the static CASCADE_MAP, so realistic-shaped dicts are enough.
+"""
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from cascade import detect_cascade
+
+
+class TestCascadeIntegration:
+    """Integration-style tests: realistic headlines through the full pipeline."""
+
+    def test_crude_oil_rise_affects_ongc(self):
+        # Arrange: a realistic RSS-shaped headline about a crude oil rally.
+        news = [
+            {
+                "title": "Crude oil surges above $85 amid supply concerns",
+                "body": "",
+                "source": "ET",
+                "date": "2026-07-10",
+                "url": "https://x.com/1",
+            },
+        ]
+
+        # Act
+        result = detect_cascade(news, ticker_lookup=None, focus_ticker="ONGC")
+
+        # Assert: ONGC has an inverse relationship to crude (direction -1),
+        # so a crude price rise is Bullish for it, not Bearish.
+        assert len(result) == 1
+        crude = result[0]
+        assert crude["driver"] == "Crude Oil"
+        assert crude["direction"] == 1  # crude price rose
+
+        ongc_entries = [a for a in crude["affects"] if a["ticker"] == "ONGC"]
+        assert len(ongc_entries) == 1
+        ongc = ongc_entries[0]
+        assert ongc["searched"] is True
+        # ticker_impact: +1 = Bearish, -1 = Bullish
+        assert ongc["ticker_impact"] == -1
+        assert "rally" in ongc["reason"].lower() or "boosts" in ongc["reason"].lower()
+
+    def test_detect_cascade_returns_expected_fields(self):
+        # Arrange: two distinct macro headlines (rupee + gold) in one batch.
+        news = [
+            {
+                "title": "Rupee weakens to 86 against US dollar",
+                "body": "",
+                "source": "ET",
+                "date": "2026-07-10",
+                "url": "https://x.com/1",
+            },
+            {
+                "title": "Gold prices jump on safe-haven demand",
+                "body": "",
+                "source": "ET",
+                "date": "2026-07-10",
+                "url": "https://x.com/2",
+            },
+        ]
+
+        # Act
+        result = detect_cascade(news)
+
+        # Assert: both drivers detected, each with the documented shape.
+        drivers = {r["driver"] for r in result}
+        assert drivers == {"Rupee / USD", "Gold"}
+
+        for driver_result in result:
+            assert set(driver_result.keys()) == {
+                "driver", "direction", "impact", "affects", "matched_articles",
+            }
+            assert driver_result["impact"] in (1, -1)
+            assert driver_result["matched_articles"] >= 1
+            assert len(driver_result["affects"]) > 0
+            for affected in driver_result["affects"]:
+                assert set(affected.keys()) == {
+                    "ticker", "reason", "company", "searched", "ticker_impact",
+                }
+                assert affected["ticker_impact"] in (1, -1)
+                assert isinstance(affected["reason"], str) and affected["reason"]
+
+    def test_cascade_no_relevant_news(self):
+        # Arrange: a headline with no commodity/macro driver keywords.
+        news = [
+            {
+                "title": "Company board meeting on March 15",
+                "body": "",
+                "source": "ET",
+                "date": "2026-07-10",
+                "url": "https://x.com/1",
+            },
+        ]
+
+        # Act
+        result = detect_cascade(news)
+
+        # Assert
+        assert result == []
+        assert len(result) == 0
+
+    def test_cascade_empty_news_list(self):
+        # Arrange
+        news = []
+
+        # Act
+        result = detect_cascade(news)
+
+        # Assert: empty input never crashes and yields empty output.
+        assert result == []
+
+    def test_cascade_filtered_by_focus_ticker(self):
+        # Arrange: crude oil (doesn't affect HINDALCO) + aluminum fall
+        # (does affect HINDALCO) in the same news batch.
+        news = [
+            {
+                "title": "Crude oil surges above $85 amid supply concerns",
+                "body": "",
+                "source": "ET",
+                "date": "2026-07-10",
+                "url": "https://x.com/1",
+            },
+            {
+                "title": "Aluminum prices fall on weak global demand",
+                "body": "",
+                "source": "ET",
+                "date": "2026-07-10",
+                "url": "https://x.com/2",
+            },
+        ]
+
+        # Act
+        result = detect_cascade(news, focus_ticker="HINDALCO")
+
+        # Assert: only the aluminum driver survives the focus_ticker filter.
+        drivers = [r["driver"] for r in result]
+        assert "Aluminum" in drivers
+        assert "Crude Oil" not in drivers  # CASCADE_MAP has no HINDALCO entry there
+
+        aluminum = [r for r in result if r["driver"] == "Aluminum"][0]
+        hindalco_entries = [a for a in aluminum["affects"] if a["ticker"] == "HINDALCO"]
+        assert len(hindalco_entries) == 1
+        hindalco = hindalco_entries[0]
+        assert hindalco["searched"] is True
+        # Aluminum falls (direction -1) x HINDALCO direction -1 => ticker_impact +1 (Bearish)
+        assert hindalco["ticker_impact"] == 1


### PR DESCRIPTION
### **Issue solving** 
#29 

### **What this does**
Adds `tests/test_integration_cascade.py`,  5 integration-style tests for `detect_cascade()` in `cascade.py`, which currently has good unit coverage (tests/test_cascade.py) but no tests exercising it against realistic, RSS-shaped news input end to end.
Each test follows Arrange/Act/Assert:

- Arrange: build news items in the same shape data_fetcher.fetch_market_headlines() produces (title, body, source, date, url)
- Act: call detect_cascade() directly — no mocking needed since it's a pure function over the news list + the static CASCADE_MAP
- Assert: check driver detection, per-ticker impact direction, and result schema


### **Note on the original issue**
The issue's example output (ticker, headline, driver_label, impact: "Bullish"/"Bearish") doesn't match the current return shape of detect_cascade(). The real function returns a list of driver-level dicts (driver, direction, impact: 1/-1, matched_articles, affects), where affects is a list of per-ticker dicts (ticker, reason, company, searched, ticker_impact). I wrote these tests against the actual current API rather than the issue's sketch, so they'll pass against main as-is. Flagging this in case the issue description should be updated, or in case there's an older/planned API shape I'm not aware of.


### **How I tested this**

`python -m pytest tests/test_cascade.py tests/test_integration_cascade.py -v`
Result: 31 passed (26 existing + 5 new), 0 failed.


<img width="1176" height="853" alt="swappy-20260709-225216" src="https://github.com/user-attachments/assets/648c3aec-5b7b-4e82-88c4-01e6886c7ba8" />

